### PR TITLE
configure matchers and receivers conditionally

### DIFF
--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.yaml: |
     logLevel: debug
 
-    {{ if .Values.Installation.V1.Secret.EventExporterApp.Slack.Webhook }}
+    {{ if .Values.Installation.V1.Secret.EventExporterApp }}
     # We do not have webhooks configured on all Control Planes since they are
     # part of an optional feature, which is sending Kubernetes Events to Slack.
     # In case the webhook is not present Helm cannot template the configmap

--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -6,8 +6,17 @@ metadata:
 data:
   config.yaml: |
     logLevel: debug
+
+    {{ if .Values.Installation.V1.Secret.EventExporterApp.Slack.Webhook }}
+    # We do not have webhooks configured on all Control Planes since they are
+    # part of an optional feature, which is sending Kubernetes Events to Slack.
+    # In case the webhook is not present Helm cannot template the configmap
+    # properly. Therefore we do not configure any matchers nor receivers if
+    # there is no webhook configured for a given Control Plane.
+
     route:
       routes:
+
         # We want to send Tenant Cluster upgrade events to Slack via the webhook
         # receiver. Therefore we match for events attached to the CAPI Cluster
         # CRs.
@@ -22,9 +31,13 @@ data:
         # the end of the tree.
         - drop:
           - namespace: "*"
+
     receivers:
+
       - name: "webhook"
         webhook:
           endpoint: "{{ .Values.Installation.V1.Secret.EventExporterApp.Slack.Webhook }}"
           layout:
             text: "Tenant Cluster upgrade got triggered for {{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }} on {{ .Values.Installation.V1.Name }}."
+
+    {{ end }}


### PR DESCRIPTION
We have the problem of failing deployments on Control Planes for which there is no webhook configured. This PR tries to resolve certain scheduling limitations by just not configuring any matchers nor receivers at all in case there is no webhook configured. Below is an error within the `App` CR status found on `ginger`. 

```
$ k get -n giantswarm -o yaml apps.application.giantswarm.io event-exporter-app-unique
...
status:
  release:
    reason: 'helm error: (template: event-exporter-app/templates/configmap.yaml:28:31:
      executing "event-exporter-app/templates/configmap.yaml" at <.Values.Installation.V1.Secret.EventExporterApp.Slack.Webhook>:
      nil pointer evaluating interface {}.Slack)'
    status: not-installed
```

With this PR the pod gets deployed again and this is how the configmap looks like. 

```
$ k -n giantswarm get -o yaml configmap event-exporter-app
...
data:
  config.yaml: |
    logLevel: debug
```