### PR TITLE
Add upgrade complete announcement event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cluster upgrade complete announcement event.
+
 ## [0.5.1] - 2021-09-10
 
 ### Fixed

--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -35,6 +35,13 @@ data:
           - kind: "Cluster"
             reason: "ClusterUpgradeAnnouncement"
             receiver: "webhook-announcement"
+        # We want to send Workload Cluster upgrade completed announcement to Slack via the webhook
+        # receiver. Therefore we match for events attached to the CAPI Cluster
+        # CRs.
+        - match:
+          - kind: "Cluster"
+            reason: "ClusterUpdated"
+            receiver: "webhook-upgrade-complete"
         {{- end }}
 
         # We want to ignore all other events once we handled the events we are
@@ -56,6 +63,11 @@ data:
           endpoint: "{{ .Values.slack.webhook }}"
           layout:
             text: "{{ "{{" }} .Message {{ "}}" }}"
+      - name: "webhook-upgrade-complete"
+        webhook:
+          endpoint: "{{ .Values.slack.webhook }}"
+          layout:
+            text: "Workload cluster upgrade completed for {{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }} on {{ .Values.managementCluster.name }}."
       {{- end }}
 
       - name: "grafana-firecracker"


### PR DESCRIPTION
Related:
* https://github.com/giantswarm/roadmap/issues/472
* https://github.com/giantswarm/upgrade-schedule-operator/pull/20

Add a Slack message to indicate when a cluster upgrade has completed.

Note: I opted for the `ClusterVersionUpdated` event over the `ClusterUpdated` event to be more in-line with the existing "version upgrade scheduled" notification. Please correct me if this isn't the right approach.