### PR TITLE
Trigger pod recreate on configmap change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Trigger the pod to recreate on configmap change
+
 ## [0.6.0] - 2021-09-28
 
 ### Added

--- a/helm/event-exporter-app/templates/deployment.yaml
+++ b/helm/event-exporter-app/templates/deployment.yaml
@@ -10,6 +10,8 @@ spec:
       labels:
         app: event-exporter-app
         version: v1
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: event-exporter-app
       containers:


### PR DESCRIPTION
When changes are made to the ConfigMap the changes aren't automatically applied to the deployed app as the config is kept in memory. This change causes any change to the configmap to force the pod to be recreated as well.