### PR TITLE
update messaging to explicitly mention rolling nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed upgrade message wording to specifically call out rolling nodes
+
 ## [0.7.0] - 2021-09-29
 
 ### Added

--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -53,21 +53,21 @@ data:
     receivers:
 
       {{- if .Values.slack }}
-      - name: "webhook-upgrade"
-        webhook:
-          endpoint: "{{ .Values.slack.webhook }}"
-          layout:
-            text: "Workload cluster upgrade triggered for {{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }} on {{ .Values.managementCluster.name }}."
       - name: "webhook-announcement"
         webhook:
           endpoint: "{{ .Values.slack.webhook }}"
           layout:
             text: "{{ "{{" }} .Message {{ "}}" }}"
+      - name: "webhook-upgrade"
+        webhook:
+          endpoint: "{{ .Values.slack.webhook }}"
+          layout:
+            text: "The cluster upgrade of { "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }} on {{ .Values.managementCluster.name }} has begun, this upgrade will include replacing of nodes."
       - name: "webhook-upgrade-complete"
         webhook:
           endpoint: "{{ .Values.slack.webhook }}"
           layout:
-            text: "Workload cluster upgrade completed for {{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }} on {{ .Values.managementCluster.name }}."
+            text: "The cluster upgrade of { "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }} on {{ .Values.managementCluster.name }} has completed and all nodes have been replaced."
       {{- end }}
 
       - name: "grafana-firecracker"


### PR DESCRIPTION
Make it clear that the upgrade in progress and complete is (currently) related to when nodes need replacing.