### PR TITLE
Add seccomp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Configured the use of the runtime/default seccomp profile. (Adding PSP, changing RBAC)
+
 ## [0.10.1] - 2022-09-14
 
 ### Changed

--- a/helm/event-exporter-app/Chart.yaml
+++ b/helm/event-exporter-app/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: event-exporter-app
-version: 1
+version: [[ .Version ]]
 appVersion: v0.10
 description: The event-exporter-app runs on Control Planes to watch and act upon Kubernetes events.
 home: https://github.com/opsgenie/kubernetes-event-exporter

--- a/helm/event-exporter-app/Chart.yaml
+++ b/helm/event-exporter-app/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: event-exporter-app
-version: [[ .Version ]]
+version: 1
 appVersion: v0.10
 description: The event-exporter-app runs on Control Planes to watch and act upon Kubernetes events.
 home: https://github.com/opsgenie/kubernetes-event-exporter

--- a/helm/event-exporter-app/templates/deployment.yaml
+++ b/helm/event-exporter-app/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           securityContext:
             {{- with .Values.securityContext }}
-              {{- . | toYaml | nindent 10 }}
+              {{- . | toYaml | nindent 12 }}
             {{- end }}
           args:
             - -conf=/data/config.yaml

--- a/helm/event-exporter-app/templates/deployment.yaml
+++ b/helm/event-exporter-app/templates/deployment.yaml
@@ -16,10 +16,18 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: event-exporter-app
+      securityContext:
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
         - name: event-exporter-app
           image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          securityContext:
+            {{- with .Values.securityContext }}
+              {{- . | toYaml | nindent 10 }}
+            {{- end }}
           args:
             - -conf=/data/config.yaml
           volumeMounts:

--- a/helm/event-exporter-app/templates/psp.yaml
+++ b/helm/event-exporter-app/templates/psp.yaml
@@ -10,17 +10,11 @@ spec:
   hostIPC: false
   hostPID: false
   fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
+    rule: RunAsAny
   runAsUser:
-    rule: MustRunAsNonRoot
+    rule: RunAsAny
   runAsGroup:
-    rule: MustRunAs
-    ranges:
-      - min: 1
-        max: 65535
+    rule: RunAsAny
   seLinux:
     rule: RunAsAny
   supplementalGroups:
@@ -28,3 +22,7 @@ spec:
   volumes:
   - configMap
   - secret
+  - emptyDIr
+  - downwardAPI
+  - persistentVolumeClaim
+  - projected

--- a/helm/event-exporter-app/templates/psp.yaml
+++ b/helm/event-exporter-app/templates/psp.yaml
@@ -22,7 +22,7 @@ spec:
   volumes:
   - configMap
   - secret
-  - emptyDIr
+  - emptyDir
   - downwardAPI
   - persistentVolumeClaim
   - projected

--- a/helm/event-exporter-app/templates/psp.yaml
+++ b/helm/event-exporter-app/templates/psp.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Values.name }}-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
+spec:
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: MustRunAsNonRoot
+  runAsGroup:
+    rule: MustRunAs
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret

--- a/helm/event-exporter-app/templates/rbac.yaml
+++ b/helm/event-exporter-app/templates/rbac.yaml
@@ -50,7 +50,7 @@ rules:
     - list
     - watch
   - apiGroups:
-    - extentions
+    - extensions
     resourceNames:
     - {{ .Values.name }}-psp
     resources:

--- a/helm/event-exporter-app/templates/rbac.yaml
+++ b/helm/event-exporter-app/templates/rbac.yaml
@@ -49,6 +49,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+    - extentions
+    resourceNames:
+    - {{ .Values.name }}-psp
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/event-exporter-app/values.schema.json
+++ b/helm/event-exporter-app/values.schema.json
@@ -1,0 +1,117 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "grafana": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "managementCluster": {
+            "type": "object",
+            "properties": {
+                "customer": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "provider": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string"
+                }
+            }
+        },
+        "registry": {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "slack": {
+            "type": "object",
+            "properties": {
+                "webhook": {
+                    "type": "string"
+                }
+            }
+        },
+        "testingEnvironment": {
+            "type": "boolean"
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/helm/event-exporter-app/values.yaml
+++ b/helm/event-exporter-app/values.yaml
@@ -35,3 +35,13 @@ project:
 
 verticalPodAutoscaler:
   enabled: true
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.