### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.11.0] - 2023-07-13
 
 ### Added

--- a/helm/event-exporter-app/values.yaml
+++ b/helm/event-exporter-app/values.yaml
@@ -8,7 +8,7 @@ image:
   #
   name: giantswarm/kubernetes-event-exporter
   pullPolicy: IfNotPresent
-  registry: docker.io
+  registry: gsoci.azurecr.io
   tag: "0.9"
 
 
@@ -27,7 +27,7 @@ grafana:
   token: ""
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 project:
   branch: "[[ .Branch ]]"
@@ -48,4 +48,4 @@ securityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
