### PR TITLE
CircleCI: Depend `push-to-app-collection` on `push-to-control-plane-catalog`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ workflows:
           context: architect
           app_name: event-exporter-app
           app_collection_repo: aws-app-collection
+          requires:
+            - push-to-control-plane-catalog
           filters:
             branches:
               ignore: /.*/
@@ -50,6 +52,8 @@ workflows:
           context: architect
           app_name: event-exporter-app
           app_collection_repo: azure-app-collection
+          requires:
+            - push-to-control-plane-catalog
           filters:
             branches:
               ignore: /.*/
@@ -61,6 +65,8 @@ workflows:
           context: architect
           app_name: event-exporter-app
           app_collection_repo: capa-app-collection
+          requires:
+            - push-to-control-plane-catalog
           filters:
             branches:
               ignore: /.*/
@@ -72,6 +78,8 @@ workflows:
           context: architect
           app_name: event-exporter-app
           app_collection_repo: capz-app-collection
+          requires:
+            - push-to-control-plane-catalog
           filters:
             branches:
               ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Templates: Rework RBAC.
   - Templates: Rework `ServiceAccount`.
   - Templates: Rework `VerticalPodAutoscaler`.
+- CircleCI: Depend `push-to-app-collection` on `push-to-control-plane-catalog`. ([#165](https://github.com/giantswarm/event-exporter-app/pull/165))
 
 ### Removed
 


### PR DESCRIPTION
Otherwise the app collections will get updated to a non-existing app version in case the push to app catalog failed.