### PR TITLE
Extend match rules to include source.component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Include source.component from the CAPI events (cluster-api-events-controller).
+
 ## [2.1.0] - 2025-04-24
 
 ### Changed

--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
         - kind: Cluster
           apiversion: cluster.x-k8s.io/v1beta1
           reason: Upgrading
+          component: "cluster-api-events-controller"
           receiver: webhook-upgrade
 
       # Cluster upgrade completed.
@@ -44,6 +45,7 @@ data:
         - kind: Cluster
           apiversion: cluster.x-k8s.io/v1beta1
           reason: Upgraded
+          component: "cluster-api-events-controller"
           receiver: webhook-upgrade-complete
 
       # AWS cluster instance refresh starting.


### PR DESCRIPTION
Preventing events from PostgreSQL clusters to trigger Slack messages.

The issue occurs because events generated for these PostgreSQL Cluster objects appear to be incorrectly populating the `involvedObject.apiVersion` field as `cluster.x-k8s.io/v1beta1` and `involvedObject.kind` as `Cluster` within the Kubernetes Event data.

The event-exporter mistakenly matches these PostgreSQL-related events against rules designed for CAPI cluster lifecycle events.