### PR TITLE
Fix Slack thread key to create unique thread per upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Include target release version in Slack thread key so each upgrade gets its own thread instead of replying to a previous upgrade's thread.
+- Include target release version from Event annotation (`giantswarm.io/target-version`) in Slack thread key so each upgrade gets its own thread instead of replying to a previous upgrade's thread. Requires cluster-api-events v1.3.0+.
 
 ## [3.6.0] - 2026-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include target release version in Slack thread key so each upgrade gets its own thread instead of replying to a previous upgrade's thread.
+
 ## [3.6.0] - 2026-01-28
 
 ### Changed

--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -95,7 +95,7 @@ data:
           name: {{ include "event-exporter.fullname" . }}-thread-cache
           namespace: {{ .Release.Namespace }}
         {{- end }}
-        threadKey: "{{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }}/{{ "{{" }} index .InvolvedObject.Annotations \"giantswarm.io/last-known-cluster-upgrade-version\" {{ "}}" }}"
+        threadKey: '{{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }}/{{ "{{" }} index .Annotations "giantswarm.io/target-version" {{ "}}" }}'
         completionCondition: '{{ "{{" }} if eq .Reason "Upgraded" }}true{{ "{{" }} end }}'
         completionEmoji: "white_check_mark"
         message: |

--- a/helm/event-exporter-app/templates/configmap.yaml
+++ b/helm/event-exporter-app/templates/configmap.yaml
@@ -95,7 +95,7 @@ data:
           name: {{ include "event-exporter.fullname" . }}-thread-cache
           namespace: {{ .Release.Namespace }}
         {{- end }}
-        threadKey: "{{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }}"
+        threadKey: "{{ "{{" }} .InvolvedObject.Namespace {{ "}}" }}/{{ "{{" }} .InvolvedObject.Name {{ "}}" }}/{{ "{{" }} index .InvolvedObject.Annotations \"giantswarm.io/last-known-cluster-upgrade-version\" {{ "}}" }}"
         completionCondition: '{{ "{{" }} if eq .Reason "Upgraded" }}true{{ "{{" }} end }}'
         completionEmoji: "white_check_mark"
         message: |


### PR DESCRIPTION
Relates to: https://gigantic.slack.com/archives/C02EVLE9W/p1773731999426769

Include the target release version (`giantswarm.io/last-known-cluster-upgrade-version` annotation from the Cluster CR) in the Slack `threadKey`. This ensures each upgrade gets its own Slack thread instead of replying to a previous upgrade's thread.

Previously the threadKey was `namespace/clusterName`, meaning all upgrades for the same cluster shared a thread. Now it's `namespace/clusterName/targetVersion`, e.g. `org-fleetio/stg-wrkld-use1/33.1.4`.